### PR TITLE
Fix panic when subtracting Duration

### DIFF
--- a/src/stores/memory.rs
+++ b/src/stores/memory.rs
@@ -123,9 +123,9 @@ impl Handler<ActorMessage> for MemoryStoreActor {
                     }
                 };
                 let dur = c.value().1;
-                let now = SystemTime::now();
-                let dur = dur - now.duration_since(UNIX_EPOCH).unwrap();
-                ActorResponse::Expire(Box::pin(future::ready(Ok(dur))))
+                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+                let res = dur.checked_sub(now).unwrap_or_else(|| Duration::new(0,0));
+                ActorResponse::Expire(Box::pin(future::ready(Ok(res))))
             }
             ActorMessage::Remove(key) => {
                 debug!("Removing key: {}", &key);


### PR DESCRIPTION
A panic can occur if `SystemTime::now()` returns a time earlier than the one found in the registry. Perform a checked_sub and return a zero Duration in this situation.
