### PR TITLE
Dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "TerminalWitchcraft/actix-ratelimit", branch = "maste
 
 default = ["dashmap"]
 redis-store = ["redis_rs", "backoff"]
-memcached = ["memcache", "backoff"]
+memcached = ["r2d2-memcache", "backoff"]
 
 [dependencies]
 log = "0.4.8"
@@ -33,7 +33,7 @@ dashmap = {version = "3.2.2", optional = true}
 
 redis_rs = {version = "0.15.1", optional = true, package= "redis"}
 backoff = {version = "0.1.6", optional = true}
-memcache = {version = "*", optional = true}
+r2d2-memcache = { version = "0.5", optional = true }
 
 [dev-dependencies]
 actix-rt = "1.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,9 @@ memcached = ["memcache", "backoff"]
 
 [dependencies]
 log = "0.4.8"
-actix-web = "2.0.0"
-actix = "0.9.0"
+actix-web = {version = "3.0.1"}
+actix-http = {version = "2.0.0", features=["actors"]}
+actix = "0.10"
 futures = "0.3.1"
 failure = "0.1.6"
 
@@ -35,6 +36,6 @@ backoff = {version = "0.1.6", optional = true}
 memcache = {version = "*", optional = true}
 
 [dev-dependencies]
-actix-rt = "1.0.0"
+actix-rt = "1.1.1"
 env_logger = "0.7.1"
 version-sync = "0.8.1"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ async fn greet(req: HttpRequest) -> impl Responder{
     format!("Hello {}!", &name)
 }
 
-#[actix_rt::main]
+#[actix_web::main]
 async fn main() -> std::io::Result<()> {
     // Initialize store
     let store = MemoryStore::new();
@@ -104,7 +104,7 @@ actix-ratelimit = {version = "0.2.1", default-features = false, features = ["red
 using [ServiceRequest](https://docs.rs/actix-web/2.0.0/actix_web/dev/struct.ServiceRequest.html) instance.
 For example, using api key header to identify client:
 ```rust
-#[actix_rt::main]
+#[actix_web::main]
 async fn main() -> std::io::Result<()> {
     // Initialize store
     let store = MemoryStore::new();
@@ -134,7 +134,7 @@ async fn main() -> std::io::Result<()> {
 will be created for each web worker. This may lead to instability and inconsistency! For
 example, initializing your app in the following manner would create more than one stores:
 ```rust
-#[actix_rt::main]
+#[actix_web::main]
 async fn main() -> std::io::Result<()> {
     HttpServer::new(move ||{
         App::new()

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Minimal example:
 ```rust
 use actix_web::{web, App, HttpRequest, HttpServer, Responder};
 use actix_ratelimit::{RateLimiter, MemoryStore, MemoryStoreActor};
+use std::time::Duration;
 
 async fn greet(req: HttpRequest) -> impl Responder{
     let name = req.match_info().get("name").unwrap_or("World!");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@
 //! # use std::time::Duration;
 //! use actix_web::{web, App, HttpRequest, HttpServer, Responder};
 //! use actix_ratelimit::{RateLimiter, MemoryStore, MemoryStoreActor};
-//! use std::time::Duration;
 //!
 //! async fn greet(req: HttpRequest) -> impl Responder{
 //!     let name = req.match_info().get("name").unwrap_or("World!");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,8 @@ pub use middleware::RateLimiter;
 pub use stores::memory::{MemoryStore, MemoryStoreActor};
 #[cfg(feature = "redis-store")]
 pub use stores::redis::{RedisStore, RedisStoreActor};
+// #[cfg(feature = "memcached")]
+// pub use stores::memcached::{MemcacheStore};
 
 use std::future::Future;
 use std::marker::Send;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //!     format!("Hello {}!", &name)
 //! }
 //!
-//! #[actix_rt::main]
+//! #[actix_web::main]
 //! async fn main() -> std::io::Result<()> {
 //!     // Initialize store
 //!     let store = MemoryStore::new();
@@ -111,7 +111,7 @@
 //! #     let name = req.match_info().get("name").unwrap_or("World!");
 //! #     format!("Hello {}!", &name)
 //! # }
-//! #[actix_rt::main]
+//! #[actix_web::main]
 //! async fn main() -> std::io::Result<()> {
 //!     // Initialize store
 //!     let store = MemoryStore::new();
@@ -150,7 +150,7 @@
 //! #     let name = req.match_info().get("name").unwrap_or("World!");
 //! #     format!("Hello {}!", &name)
 //! # }
-//! #[actix_rt::main]
+//! #[actix_web::main]
 //! async fn main() -> std::io::Result<()> {
 //!     HttpServer::new(move ||{
 //!         App::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 //! # use std::time::Duration;
 //! use actix_web::{web, App, HttpRequest, HttpServer, Responder};
 //! use actix_ratelimit::{RateLimiter, MemoryStore, MemoryStoreActor};
+//! use std::time::Duration;
 //!
 //! async fn greet(req: HttpRequest) -> impl Responder{
 //!     let name = req.match_info().get("name").unwrap_or("World!");

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -63,7 +63,7 @@ where
         let identifier = |req: &ServiceRequest| {
             let connection_info = req.connection_info();
             let ip = connection_info
-                .remote()
+                .remote_addr()
                 .ok_or(ARError::IdentificationError)?;
             Ok(String::from(ip))
         };

--- a/src/stores/memory.rs
+++ b/src/stores/memory.rs
@@ -123,9 +123,9 @@ impl Handler<ActorMessage> for MemoryStoreActor {
                     }
                 };
                 let dur = c.value().1;
-                let now = SystemTime::now();
-                let dur = dur - now.duration_since(UNIX_EPOCH).unwrap();
-                ActorResponse::Expire(Box::pin(future::ready(Ok(dur))))
+                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+                let res = dur.checked_sub(now).unwrap_or_else(|| Duration::new(0,0));
+                ActorResponse::Expire(Box::pin(future::ready(Ok(res))))
             }
             ActorMessage::Remove(key) => {
                 debug!("Removing key: {}", &key);

--- a/src/stores/memory.rs
+++ b/src/stores/memory.rs
@@ -87,7 +87,11 @@ impl Handler<ActorMessage> for MemoryStoreActor {
             ActorMessage::Update { key, value } => match self.inner.get_mut(&key) {
                 Some(mut c) => {
                     let val_mut: &mut (usize, Duration) = c.value_mut();
-                    val_mut.0 -= value;
+                    if val_mut.0 > value {
+                        val_mut.0 -= value;
+                    } else {
+                        val_mut.0 = 0;
+                    }
                     let new_val = val_mut.0;
                     ActorResponse::Update(Box::pin(future::ready(Ok(new_val))))
                 }

--- a/src/stores/memory.rs
+++ b/src/stores/memory.rs
@@ -128,7 +128,7 @@ impl Handler<ActorMessage> for MemoryStoreActor {
                 };
                 let dur = c.value().1;
                 let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-                let res = dur.checked_sub(now).unwrap_or_else(|| Duration::new(0,0));
+                let res = dur.checked_sub(now).unwrap_or_else(|| Duration::new(0, 0));
                 ActorResponse::Expire(Box::pin(future::ready(Ok(res))))
             }
             ActorMessage::Remove(key) => {

--- a/src/stores/mod.rs
+++ b/src/stores/mod.rs
@@ -8,7 +8,7 @@
 //! When a new key is created, tokens are assigned to it based on the value of _max_requests_ which
 //! are valid for an _interval_. Once time has elapsed equal to the _interval_, the key is removed
 //! from the store. Memory store uses deferred messages to the actor to accomplish this, whereas
-//! key expiry is used for redis.  
+//! key expiry is used for redis.
 //!
 //! Store actors are implemented as supervised actors, and if you implement your own store, it is
 //! recommended to implement it as a Supervised actor to achieve some level of fault tolerance.
@@ -85,5 +85,5 @@ pub mod memory;
 #[cfg(feature = "redis-store")]
 pub mod redis;
 
-// #[cfg(feature = "memcached")]
-// pub mod memcached;
+#[cfg(feature = "memcached")]
+pub mod memcached;

--- a/src/stores/mod.rs
+++ b/src/stores/mod.rs
@@ -85,5 +85,5 @@ pub mod memory;
 #[cfg(feature = "redis-store")]
 pub mod redis;
 
-#[cfg(feature = "memcached")]
-pub mod memcached;
+// #[cfg(feature = "memcached")]
+// pub mod memcached;


### PR DESCRIPTION
Hi, 

The problem with the lifetime of memcache was because the Client was not thread aware, so could not be cloned across thread, to avoid this problem I used r2d2-memcache that actually depend from it, and provide a pool that can be cloned and sent safely across thread, I hope this can help you to finish up your implementation and release the 3.0