### PR TITLE
fixed memory module to be enabled when memory feature is enabled

### DIFF
--- a/src/stores/mod.rs
+++ b/src/stores/mod.rs
@@ -79,7 +79,7 @@
 //!
 //! The above example is not thread-safe and does not implement key expiration! It's just for demonstration purposes.
 
-#[cfg(feature = "default")]
+#[cfg(feature = "memory")]
 pub mod memory;
 
 #[cfg(feature = "redis-store")]


### PR DESCRIPTION
Running `cargo test --no-default-features --features=memory` produce a compilation error that this PR fix