### PR TITLE
Upgrade the project to Actix 4.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ memcached = ["r2d2-memcache", "backoff"]
 
 [dependencies]
 log = "0.4.11"
-actix-web = {version = "3.3.2"}
-actix-http = {version = "2.2.0", features=["actors"]}
+actix-web = {version = "4.0.0-beta.1"}
+actix-http = {version = "3.0.0-beta.1", features=["actors"]}
 actix = "0.10"
 futures = "0.3.8"
 failure = "0.1.8"
@@ -37,6 +37,6 @@ backoff = {version = "0.2.1", optional = true}
 r2d2-memcache = { version = "0.5", optional = true }
 
 [dev-dependencies]
-actix-rt = "1.1.1"
+actix-rt = "2.0.0-beta.2"
 env_logger = "0.8.2"
 version-sync = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ memcached = ["r2d2-memcache", "backoff"]
 log = "0.4.11"
 actix-web = {version = "4.0.0-beta.1"}
 actix-http = {version = "3.0.0-beta.1", features=["actors"]}
-actix = "0.10"
+actix = "0.11.0-beta.1"
 futures = "0.3.8"
 failure = "0.1.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ memcached = ["r2d2-memcache", "backoff"]
 
 [dependencies]
 log = "0.4.11"
-actix-web = {version = "3.3.2"}
+actix-web = {version = "4.0.0-beta.1"}
 actix-http = {version = "2.2.0", features=["actors"]}
-actix = "0.10"
+actix = { git = "https://github.com/actix/actix" }
 futures = "0.3.8"
 failure = "0.1.8"
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -101,11 +101,10 @@ impl<T, S, B> Transform<S> for RateLimiter<T>
 where
     T: Handler<ActorMessage> + Send + Sync + 'static,
     T::Context: ToEnvelope<T, ActorMessage>,
-    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = AWError> + 'static,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = AWError> + 'static,
     S::Future: 'static,
     B: 'static,
 {
-    type Request = ServiceRequest;
     type Response = ServiceResponse<B>;
     type Error = S::Error;
     type InitError = ();
@@ -140,12 +139,11 @@ where
 impl<T, S, B> Service for RateLimitMiddleware<S, T>
 where
     T: Handler<ActorMessage> + 'static,
-    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = AWError> + 'static,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = AWError> + 'static,
     S::Future: 'static,
     B: 'static,
     T::Context: ToEnvelope<T, ActorMessage>,
 {
-    type Request = ServiceRequest;
     type Response = ServiceResponse<B>;
     type Error = S::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -3,6 +3,7 @@ use actix::dev::*;
 use actix_web::{
     dev::{Service, ServiceRequest, ServiceResponse, Transform},
     error::Error as AWError,
+    error::ErrorInternalServerError,
     http::{HeaderName, HeaderValue},
     HttpResponse,
 };
@@ -97,7 +98,7 @@ where
     }
 }
 
-impl<T, S, B> Transform<S> for RateLimiter<T>
+impl<T, S, B> Transform<S, ServiceRequest> for RateLimiter<T>
 where
     T: Handler<ActorMessage> + Send + Sync + 'static,
     T::Context: ToEnvelope<T, ActorMessage>,
@@ -136,7 +137,7 @@ where
     identifier: Rc<Box<dyn Fn(&ServiceRequest) -> Result<String, ARError> + 'static>>,
 }
 
-impl<T, S, B> Service for RateLimitMiddleware<S, T>
+impl<T, S, B> Service<ServiceRequest> for RateLimitMiddleware<S, T>
 where
     T: Handler<ActorMessage> + 'static,
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = AWError> + 'static,
@@ -162,7 +163,7 @@ where
             let identifier: String = (identifier)(&req)?;
             let remaining: ActorResponse = store
                 .send(ActorMessage::Get(String::from(&identifier)))
-                .await?;
+                .await.map_err(ErrorInternalServerError)?;
             match remaining {
                 ActorResponse::Get(opt) => {
                     let opt = opt.await?;
@@ -170,7 +171,7 @@ where
                         // Existing entry in store
                         let expiry = store
                             .send(ActorMessage::Expire(String::from(&identifier)))
-                            .await?;
+                            .await.map_err(ErrorInternalServerError)?;
                         let reset: Duration = match expiry {
                             ActorResponse::Expire(dur) => dur.await?,
                             _ => unreachable!(),
@@ -190,7 +191,7 @@ where
                                     key: identifier,
                                     value: 1,
                                 })
-                                .await?;
+                                .await.map_err(ErrorInternalServerError)?;
                             let updated_value: usize = match res {
                                 ActorResponse::Update(c) => c.await?,
                                 _ => unreachable!(),
@@ -223,7 +224,7 @@ where
                                 value: current_value,
                                 expiry: interval,
                             })
-                            .await?;
+                            .await.map_err(ErrorInternalServerError)?;
                         match res {
                             ActorResponse::Set(c) => c.await?,
                             _ => unreachable!(),

--- a/src/stores/mod.rs
+++ b/src/stores/mod.rs
@@ -79,7 +79,7 @@
 //!
 //! The above example is not thread-safe and does not implement key expiration! It's just for demonstration purposes.
 
-#[cfg(feature = "default")]
+#[cfg(feature = "memory")]
 pub mod memory;
 
 #[cfg(feature = "redis-store")]


### PR DESCRIPTION
This is not yet finalized, as there is some substantial change in the source code. 

More specifically, there happen to have Request type param removed in several traits, and that MailboxError does not implement ResponseError anymore. I substituted ServiceRequest into the type param and it should work as intended.

I workaround the latter by adding an extra function call ErrorInternalServerError using map_err to wrap the error up. It's a convenient workaround but it's not very effective. I checked the diff from 3.x to 4.x and see that from MailboxError to ResponseError is transformed to an ISE, this is how I come up with this idea.

Yet, copy pasting map_err(ErrorInternalServerError) isn't very fun and tedious, but since this is an upstream Actix problem, why don't we just go blind first for a few moments. 

Until the review passed on the ISE part and all the crate has graduated from beta then, let's keep it a draft.